### PR TITLE
Add support for local button icons

### DIFF
--- a/firefox/template-app/lib/main.js
+++ b/firefox/template-app/lib/main.js
@@ -126,6 +126,11 @@ var apiImpl = {
 	},
 	button: {
 		setIcon: function (url, success, error) {
+			// If schema not given, then assume local file; patch up url to be relative to data folder.
+			if (url.indexOf("://") < 0) {
+			    url = data.url(url);
+			}
+
 			if (button) {
 				button.update({
 					icon: url


### PR DESCRIPTION
Added fix in firefox template code to allow us to easily include local resource image files as the button icon.
