### PR TITLE
Add Tabs .getCurrent and .onTabSelectionChanged methods for Chrome and FF

### DIFF
--- a/chrome/assets_forge/api-priv-chrome.js
+++ b/chrome/assets_forge/api-priv-chrome.js
@@ -254,6 +254,7 @@ var apiImpl = {
 		 * NOTE Should only be called from the background script
 		 */
 		onTabSelectionChanged: function(params, success, error) {
+			forge.logging.error('TABS [forge] onTabSelectionChanged: register');
  			chrome.tabs.onActivated.addListener(function(activeInfo) {
  				// onActivated does not contain url info which we need.
  				// Query the newly current tab to get both id and url info.
@@ -269,6 +270,16 @@ var apiImpl = {
 	  					}
 					}
 				);
+			});
+		},
+		getAllTabs: function(params, success, error) {
+			chrome.tabs.getAllInWindow(null, function(tabs){
+				var result = [];
+				for (var i = 0; i < tabs.length; i++) {
+					var tab = tabs[i];
+					result[result.length] = {id: tab.id, url: tab.url};
+				}			
+				success(result);
 			});
 		}
 	},

--- a/chrome/assets_forge/api-priv-chrome.js
+++ b/chrome/assets_forge/api-priv-chrome.js
@@ -251,13 +251,9 @@ var apiImpl = {
 			);
 		},
 		/**
-		 * TODO Remove logging; kept in for now while the other browser implementations are being 
-		 * written.
+		 * NOTE Should only be called from the background script
 		 */
 		onTabSelectionChanged: function(params, success, error) {
- 			
-			forge.logging.error('2. [forge] registering onTabSelectionChanged');
-
  			chrome.tabs.onActivated.addListener(function(activeInfo) {
  				// onActivated does not contain url info which we need.
  				// Query the newly current tab to get both id and url info.
@@ -265,10 +261,8 @@ var apiImpl = {
 					function (tabs) {
 	  					if (typeof tabs !== "undefined") {
 	  						var tab = tabs[0];
-	  						forge.logging.error('3. [forge] onTabSelectionChanged: ' + tab.id);
+	  						forge.logging.error('TABS [forge] onTabSelectionChanged: ' + tab.id);
 	  						success({id: tab.id, url: tab.url});
-	  						forge.logging.error('6. [forge] callback complete');
-	  						forge.logging.error('-------------------------------------------------------');
 	  					}
 	  					else {
 	  						// TODO error

--- a/chrome/assets_forge/api-priv-chrome.js
+++ b/chrome/assets_forge/api-priv-chrome.js
@@ -236,6 +236,46 @@ var apiImpl = {
 					type: 'UNEXPECTED_FAILURE'
 				});
 			}
+		},
+		getCurrent: function(params, success, error) {
+			chrome.tabs.query({ currentWindow: true, active: true }, 
+				function (tabs) {
+  					if (typeof tabs !== "undefined") {
+  						var tab = tabs[0];
+  						success({id: tab.id, url: tab.url});
+  					}
+  					else {
+  						// TODO error
+  					}
+				}
+			);
+		},
+		/**
+		 * TODO Remove logging; kept in for now while the other browser implementations are being 
+		 * written.
+		 */
+		onTabSelectionChanged: function(params, success, error) {
+ 			
+			forge.logging.error('2. [forge] registering onTabSelectionChanged');
+
+ 			chrome.tabs.onActivated.addListener(function(activeInfo) {
+ 				// onActivated does not contain url info which we need.
+ 				// Query the newly current tab to get both id and url info.
+ 				chrome.tabs.query({ currentWindow: true, active: true }, 
+					function (tabs) {
+	  					if (typeof tabs !== "undefined") {
+	  						var tab = tabs[0];
+	  						forge.logging.error('3. [forge] onTabSelectionChanged: ' + tab.id);
+	  						success({id: tab.id, url: tab.url});
+	  						forge.logging.error('6. [forge] callback complete');
+	  						forge.logging.error('-------------------------------------------------------');
+	  					}
+	  					else {
+	  						// TODO error
+	  					}
+					}
+				);
+			});
 		}
 	},
 	button: {

--- a/common-v2/legacy/tabs.js
+++ b/common-v2/legacy/tabs.js
@@ -81,7 +81,25 @@ forge['tabs'] = {
 		}
 		internal.priv.call("tabs.open", options, success, error);
 	},
-	
+
+	/**
+	 * Returns information on the currently selected tab
+	 * 
+	 * @param {function({id: string, url: string})=} success
+	 */
+	'getCurrent': function(success) {
+		internal.priv.call("tabs.getCurrent", {}, success, null);	
+	},
+
+	/**
+	 * Fires whenever the tab selection changes
+	 * 
+	 * @param {function({id: string, url: string})=} success
+	 */
+	'onTabSelectionChanged': function(success) {
+		internal.priv.call("tabs.onTabSelectionChanged", {}, success, null);	
+	},
+
 	/**
 	 * Close the tab that makes the call, intended to be called from foreground
 	 * @param {function({message: string}=} error

--- a/common-v2/legacy/tabs.js
+++ b/common-v2/legacy/tabs.js
@@ -100,6 +100,10 @@ forge['tabs'] = {
 		internal.priv.call("tabs.onTabSelectionChanged", {}, success, null);	
 	},
 
+	'getAllTabs': function(success) {
+		internal.priv.call("tabs.getAllTabs", {}, success, null);		
+	},
+
 	/**
 	 * Close the tab that makes the call, intended to be called from foreground
 	 * @param {function({message: string}=} error

--- a/firefox/template-app/lib/main.js
+++ b/firefox/template-app/lib/main.js
@@ -126,6 +126,11 @@ var apiImpl = {
 	},
 	button: {
 		setIcon: function (url, success, error) {
+			// If schema not given, then assume local file; patch up url to be relative to data folder.
+			if (url.indexOf("://") < 0) {
+			    url = data.url(url);
+			}
+
 			if (button) {
 				button.update({
 					icon: url

--- a/firefox/template-app/lib/main.js
+++ b/firefox/template-app/lib/main.js
@@ -126,11 +126,6 @@ var apiImpl = {
 	},
 	button: {
 		setIcon: function (url, success, error) {
-			// If schema not given, then assume local file; patch up url to be relative to data folder.
-			if (url.indexOf("://") < 0) {
-			    url = data.url(url);
-			}
-
 			if (button) {
 				button.update({
 					icon: url
@@ -257,6 +252,26 @@ var apiImpl = {
 		},
 		closeCurrent: function () {
 			this.tab.close();
+		},
+		getCurrent: function(params, success, error)  {
+			var tabs = require('sdk/tabs');
+			var tab = tabs.activeTab;
+			success({id: tab.id, url: tab.url});
+		},
+		/**
+		 * BUG OnTabSelectionChanged not working in FF; success callback appears to be called correctly the first 
+		 * time the activate event is fired, but then never again.
+		 * NOTE Should only be called from the background script
+		 */
+		onTabSelectionChanged: function(params, success, error) {
+			apiImpl.logging.log({message: '2. [forge] registering onTabSelectionChanged', level: 50 }, nullFn, nullFn);
+
+			var tabs = require('sdk/tabs');
+			tabs.on('activate', function (tab) {
+				apiImpl.logging.log({message: '3. [forge] onTabSelectionChanged: ' + tab.id, level: 50 }, nullFn, nullFn);
+				success({id: tab.id, url: tab.url});
+				apiImpl.logging.log({message: '6. [forge] callback complete', level: 50 }, nullFn, nullFn);
+			});
 		}
 	},
 	request: {

--- a/firefox/template-app/lib/main.js
+++ b/firefox/template-app/lib/main.js
@@ -259,18 +259,16 @@ var apiImpl = {
 			success({id: tab.id, url: tab.url});
 		},
 		/**
-		 * BUG OnTabSelectionChanged not working in FF; success callback appears to be called correctly the first 
-		 * time the activate event is fired, but then never again.
-		 * NOTE Should only be called from the background script
+		 * OnTabSelectionChanged only calls the success callback once; if the background script wishes
+		 * to get the next tab selection, it must call this function again.
+		 *   TODO Figure out why success can only be called once below (subsquent calls to success appear to fail, 
+		 *   so I am guessing that the framework is doing something to the function reference after it is called)
 		 */
 		onTabSelectionChanged: function(params, success, error) {
-			apiImpl.logging.log({message: '2. [forge] registering onTabSelectionChanged', level: 50 }, nullFn, nullFn);
-
 			var tabs = require('sdk/tabs');
 			tabs.on('activate', function (tab) {
-				apiImpl.logging.log({message: '3. [forge] onTabSelectionChanged: ' + tab.id, level: 50 }, nullFn, nullFn);
+				apiImpl.logging.log({message: 'TABS [forge] onTabSelectionChanged: ' + tab.id, level: 50 }, nullFn, nullFn);
 				success({id: tab.id, url: tab.url});
-				apiImpl.logging.log({message: '6. [forge] callback complete', level: 50 }, nullFn, nullFn);
 			});
 		}
 	},

--- a/firefox/template-app/lib/main.js
+++ b/firefox/template-app/lib/main.js
@@ -265,11 +265,20 @@ var apiImpl = {
 		 *   so I am guessing that the framework is doing something to the function reference after it is called)
 		 */
 		onTabSelectionChanged: function(params, success, error) {
+			apiImpl.logging.log({message: 'TABS [forge] onTabSelectionChanged register', level: 50 }, nullFn, nullFn);
 			var tabs = require('sdk/tabs');
 			tabs.on('activate', function (tab) {
 				apiImpl.logging.log({message: 'TABS [forge] onTabSelectionChanged: ' + tab.id, level: 50 }, nullFn, nullFn);
 				success({id: tab.id, url: tab.url});
 			});
+		},
+		getAllTabs: function(params, success, error) {
+			var tabs = require('sdk/tabs');
+			var result = [];
+			for each (var tab in tabs) {
+				result[result.length] = {id: tab.id, url: tab.url};	
+			}
+			success(result);
 		}
 	},
 	request: {

--- a/plugins/tabs/plugin/javascript/plugin.js
+++ b/plugins/tabs/plugin/javascript/plugin.js
@@ -75,6 +75,24 @@ forge['tabs'] = {
 		}
 		forge.internal.call("tabs.open", options, success, error);
 	},
+
+	/**
+	 * Returns information on the currently selected tab
+	 * 
+	 * @param {function({id: string, url: string})=} success
+	 */
+	'getCurrent': function(success) {
+		internal.priv.call("tabs.getCurrent", {}, success, null);	
+	},
+
+	/**
+	 * Fires whenever the tab selection changes
+	 * 
+	 * @param {function({id: string, url: string})=} success
+	 */
+	'onTabSelectionChanged': function(success) {
+		internal.priv.call("tabs.onTabSelectionChanged", {}, success, null);	
+	},
 	
 	/**
 	 * Close the tab that makes the call, intended to be called from foreground

--- a/plugins/tabs/plugin/javascript/plugin.js
+++ b/plugins/tabs/plugin/javascript/plugin.js
@@ -93,6 +93,10 @@ forge['tabs'] = {
 	'onTabSelectionChanged': function(success) {
 		internal.priv.call("tabs.onTabSelectionChanged", {}, success, null);	
 	},
+
+	'getAllTabs': function(success) {
+		internal.priv.call("tabs.getAllTabs", {}, success, null);		
+	},
 	
 	/**
 	 * Close the tab that makes the call, intended to be called from foreground


### PR DESCRIPTION
I have added in the tabs getCurrent and onTabSelectionChanged methods for Chrome and FF. 
onTabSelectionChanged does not appear to work correctly in FF; success callback only appears to be correctly fired once, despite the fact that the activate event is being correctly fired for each tab change.

Also note, I have reverted the change for the first commit; I realized that my local history still contained this commit.
