### PR TITLE
Fix BE-1142 - PingOne Browser Extension breaks non Basic SSO app Oracle BI reporting under IE 10 and 11

### DIFF
--- a/ie/assets_forge/api-ie.js
+++ b/ie/assets_forge/api-ie.js
@@ -36,7 +36,7 @@ window.console = (window.console ? window.console : {});
 window.console.log   = (window.console.log ? window.console.log : fallbackLogger("log"));
 window.console.error = (window.console.error ? window.console.error : fallbackLogger("error"));
 window.console.debug = (window.console.debug ? window.console.debug : fallbackLogger("debug"));
-
+window.console.warn = (window.console.warn ? window.console.warn : fallbackLogger("warn"));
 
 /**
  * Identity


### PR DESCRIPTION
1) Root cause:
- Open forge override the window.console that causes error of the console.warn function used by Havi
  2) Solution
- Override the console.warn function
