### PR TITLE
BE-1670: Mark BE as Firefox e10s compatible

### DIFF
--- a/firefox/addon-sdk/app-extension/install.rdf
+++ b/firefox/addon-sdk/app-extension/install.rdf
@@ -18,6 +18,7 @@
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>36.0</em:minVersion>
         <em:maxVersion>41.0</em:maxVersion>
+        <em:multiprocessCompatible>true</em:multiprocessCompatible>
       </Description>
     </em:targetApplication>
 


### PR DESCRIPTION
This Boolean value has declared to guarantee BE addon to be compatible with multiprocess Firefox from now.
