### PR TITLE
BE-2268: Prevent jQueryBE to be register in AMD

### DIFF
--- a/common-v2/all-prefix.js
+++ b/common-v2/all-prefix.js
@@ -1,7 +1,10 @@
 // BE-2268
 // Prevent jQueryBE to be register in AMD
 // which cause conflict when client site use RequireJS
-var tmpDefine = define; define = undefined;
+if (typeof define === "function" && define.amd) {
+    window.tmpDefine = define; 
+    define = undefined;
+}
 
 (function () {
     if (document.all && !document.addEventListener) {

--- a/common-v2/all-prefix.js
+++ b/common-v2/all-prefix.js
@@ -1,3 +1,8 @@
+// BE-2268
+// Prevent jQueryBE to be register in AMD
+// which cause conflict when client site use RequireJS
+var tmpDefine = define; define = undefined;
+
 (function () {
     if (document.all && !document.addEventListener) {
         console.log('[PingOne] IE8 and below are not supported!');

--- a/common-v2/all-suffix.js
+++ b/common-v2/all-suffix.js
@@ -1,3 +1,7 @@
 
 // END concatenate_files
 })();
+
+// BE-2268
+// Restore [define] to it original
+define = tmpDefine;

--- a/common-v2/all-suffix.js
+++ b/common-v2/all-suffix.js
@@ -3,5 +3,7 @@
 })();
 
 // BE-2268
-// Restore [define] to it original
-define = tmpDefine;
+// Restore [define] to its original
+if (typeof tmpDefine === "function" && tmpDefine.amd) {
+    define = tmpDefine;
+}


### PR DESCRIPTION
- Root cause: RequireJS use jQuery load by BE (which is deleted later by BE)
- Solution: prevent BE to register jQuery as RequireJS module