### PR TITLE
BE-2553 [IE] Get script error when turn off options: Disable script debugging

### DIFF
--- a/common-v2/all-prefix.js
+++ b/common-v2/all-prefix.js
@@ -2,7 +2,7 @@
 // Prevent jQueryBE to be register in AMD
 // which cause conflict when client site use RequireJS
 if (typeof define === "function" && define.amd) {
-    window.tmpDefine = define; 
+    window.tmpDefine = define;
     define = undefined;
 }
 
@@ -10,5 +10,24 @@ if (typeof define === "function" && define.amd) {
     if (document.all && !document.addEventListener) {
         console.log('[PingOne] IE8 and below are not supported!');
         return;
+    }
+
+    if (typeof document.documentMode === 'number') {
+        if (document.documentMode <= 8) {
+            if (typeof console === 'object') {
+                if (typeof console.log === 'function') {
+                    console.log('[PingOne] IE8 and below are not supported!');
+                }
+            }
+            return;
+        } else {
+            // BE-2553
+            // When un-checking the setting, BHO can't re-init objects: window.extensions, window.messaging & window.accessible
+            // => request the user to restart their browser.
+            if (typeof window.extensions !== 'object' && typeof window.messaging !== 'object' && typeof window.accessible !== 'object') {
+                alert('[PingOne] Please restart your browser!');
+                return;
+            }
+        }
     }
     // START concatenate_files

--- a/common-v2/all-prefix.js
+++ b/common-v2/all-prefix.js
@@ -19,7 +19,7 @@ if (typeof define === "function" && define.amd) {
             // BE-2553
             // When un-checking the setting, BHO can't re-init objects: window.extensions, window.messaging & window.accessible
             // => request the user to restart their browser.
-            if (typeof window.extensions !== 'object' && typeof window.messaging !== 'object' && typeof window.accessible !== 'object') {
+            if (typeof window.extensions !== 'object' || typeof window.messaging !== 'object' || typeof window.accessible !== 'object') {
                 alert('[PingOne] Please restart your browser!');
                 return;
             }

--- a/common-v2/all-prefix.js
+++ b/common-v2/all-prefix.js
@@ -7,11 +7,6 @@ if (typeof define === "function" && define.amd) {
 }
 
 (function () {
-    if (document.all && !document.addEventListener) {
-        console.log('[PingOne] IE8 and below are not supported!');
-        return;
-    }
-
     if (typeof document.documentMode === 'number') {
         if (document.documentMode <= 8) {
             if (typeof console === 'object') {


### PR DESCRIPTION
This pull has included the fix for BE-2554. 
**BE-2553:**
The root cause of BE-2553:   When un-checking the **Disable script debugging (Other)** setting, BHO can't re-init objects: window.extensions, window.messaging & window.accessible
Solution: request the user to restart their browser. In addition, it is needed to cover exceptions that can happen in the other places (review the pull request below).
https://hg-od01.corp.pingidentity.com/r/#/c/33636/1/open-forge/projects/cdp-extension/src/resources/production/popup.js
**BE-2554**
The root cause of BE-2554: the check condition works wrong. This leads to when unchecking **Disable script debugging (Internet Explorer) setting**, IE can catch all exceptions in the BE source code injected into **irrelevant pages**, which is run under documentMode <= 8.
Solution: correct the check.