### PR TITLE
SSD-6272: fix two forge functions

### DIFF
--- a/chrome/assets_forge/api-priv-chrome.js
+++ b/chrome/assets_forge/api-priv-chrome.js
@@ -129,7 +129,14 @@ forge.is.desktop = function () {
  * @return {boolean}
  */
 forge.is.chrome = function () {
-	return true;
+    return navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
+};
+
+/**
+ * @return {boolean}
+ */
+forge.is.firefox = function () {
+    return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 };
 
 // Private API implementation


### PR DESCRIPTION
As BE code for Firefox is copied 100% from Chrome, forge.is.firefox() doesn't work correctly => needs to fix it.
-- Ngoc Nguyen --