### PR TITLE
BE-1408: [IE issue] BE popup on IE should resize automaticlly to fit its content

### DIFF
--- a/ie/source/forge/BrowserControl.cpp
+++ b/ie/source/forge/BrowserControl.cpp
@@ -285,7 +285,7 @@ void __stdcall BrowserControl::OnDocumentComplete(IDispatch *idispatch,
     htmlElement2->get_scrollWidth(&width);
     htmlElement2->get_scrollHeight(&height);
     width  = 425;       // approx chrome's maximum size
-    height = 330;      //
+    height = 350;      //
 
     // Get page color
     CComVariant v;


### PR DESCRIPTION
- Root cause: Chrome's & FF's Popup resize automatically to fit their content, but IE is not, IE's popup is set a fixed value for width and height, when content of popup is bigger than the fixed size of IE, IE's popup will appear scrollbar.
- Solution: set new heigh value for IE's popup to fit with the content