### PR TITLE
STAGING-8549 - Unexpected prompt to restart browser

### DIFF
--- a/common-v2/all-prefix.js
+++ b/common-v2/all-prefix.js
@@ -28,11 +28,19 @@ if (typeof define === "function" && define.amd) {
             // When un-checking the setting, BHO can't re-init objects: window.extensions, window.messaging & window.accessible
             // => request the user to restart their browser.
             if (typeof window.extensions !== 'object' && typeof window.messaging !== 'object' && typeof window.accessible !== 'object') {
-                if (inIframe()) {
-                    // do nothing
-                } else {
-                    alert('[PingOne] Please restart your browser!');
-                }
+
+                // There's a case when user open a popup/window from their site, BHO fail when attach forge (Access's denied when GetDispID)
+                // and it's lead to window.extensions, window.messaging and window.accessible is undefined.
+                // => This alert will be prompted and annoy user since restart doesn't resolve problem.
+                // User will see this alert again when go back to this site after restart.
+                // So I rem this code as a workaround and will try to find another solution for this issue later
+
+                // if (inIframe()) {
+                //     // do nothing
+                // } else {
+                //     alert('[PingOne] Please restart your browser!');
+                // }
+
                 return;
             }
         }


### PR DESCRIPTION
**Root cause**: Our fixed for ticket BE-2553 does not cover all case. There's a case when user open a popup/window from their site, BHO fail when attach forge (Access's denied when GetDispID). This alert will be prompted and annoy user since restart browser doesn't resolve problem.

**Solution**: as a work-around, I decide to not show this alert so it wont annoy user and try to find another solution to fix the issue when BHO fail to attach needed object.